### PR TITLE
Implement full URL rewriting proxy for complete page rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cz-web-proxy",
-  "version": "1.0.0",
-  "description": "Czech IP Web Proxy via Azure - routes requests through Czech proxy server",
+  "version": "1.1.0",
+  "description": "Czech IP Web Proxy via Azure - routes requests through Czech proxy server with full URL rewriting",
   "main": "server.js",
   "scripts": {
     "start": "node server.js"
@@ -10,6 +10,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "cheerio": "^1.0.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const http = require('http');
 const https = require('https');
 const { URL } = require('url');
+const cheerio = require('cheerio');
 
 const app = express();
 const PORT = process.env.PORT || 8080;
@@ -9,14 +10,176 @@ const PORT = process.env.PORT || 8080;
 // Czech proxy backend
 const PROXY_BACKEND = 'http://proxy.unas.cz';
 
+/**
+ * Resolve a URL relative to a base URL
+ */
+function resolveUrl(baseUrl, relativeUrl) {
+  if (!relativeUrl || relativeUrl.startsWith('data:') || relativeUrl.startsWith('javascript:') || relativeUrl.startsWith('#')) {
+    return null;
+  }
+  
+  try {
+    // Handle protocol-relative URLs
+    if (relativeUrl.startsWith('//')) {
+      const baseUrlObj = new URL(baseUrl);
+      return `${baseUrlObj.protocol}${relativeUrl}`;
+    }
+    
+    // Handle absolute URLs
+    if (relativeUrl.startsWith('http://') || relativeUrl.startsWith('https://')) {
+      return relativeUrl;
+    }
+    
+    // Handle root-relative and relative URLs
+    return new URL(relativeUrl, baseUrl).href;
+  } catch (e) {
+    return null;
+  }
+}
+
+/**
+ * Create a proxied URL for a given target URL
+ */
+function createProxyUrl(targetUrl, proxyBase, endpoint = 'fetch') {
+  if (!targetUrl) return null;
+  return `${proxyBase}/${endpoint}?url=${encodeURIComponent(targetUrl)}`;
+}
+
+/**
+ * Rewrite URLs in HTML content
+ */
+function rewriteHtml(html, baseUrl, proxyBase) {
+  const $ = cheerio.load(html, { decodeEntities: false });
+  
+  // Attributes that contain URLs
+  const urlAttributes = [
+    { selector: '[href]', attr: 'href' },
+    { selector: '[src]', attr: 'src' },
+    { selector: '[action]', attr: 'action' },
+    { selector: '[data-src]', attr: 'data-src' },
+    { selector: '[data-href]', attr: 'data-href' },
+    { selector: '[poster]', attr: 'poster' },
+    { selector: '[data-lazy-src]', attr: 'data-lazy-src' },
+    { selector: '[data-original]', attr: 'data-original' },
+  ];
+  
+  urlAttributes.forEach(({ selector, attr }) => {
+    $(selector).each((_, elem) => {
+      const $elem = $(elem);
+      const originalUrl = $elem.attr(attr);
+      const resolvedUrl = resolveUrl(baseUrl, originalUrl);
+      
+      if (resolvedUrl) {
+        // For links, use /browse to maintain browsing context
+        const tagName = elem.tagName?.toLowerCase();
+        const isLink = tagName === 'a' && attr === 'href';
+        const endpoint = isLink ? 'browse' : 'fetch';
+        $elem.attr(attr, createProxyUrl(resolvedUrl, proxyBase, endpoint));
+      }
+    });
+  });
+  
+  // Handle srcset attribute (responsive images)
+  $('[srcset]').each((_, elem) => {
+    const $elem = $(elem);
+    const srcset = $elem.attr('srcset');
+    if (srcset) {
+      const rewrittenSrcset = srcset.split(',').map(entry => {
+        const parts = entry.trim().split(/\s+/);
+        if (parts.length >= 1) {
+          const resolvedUrl = resolveUrl(baseUrl, parts[0]);
+          if (resolvedUrl) {
+            parts[0] = createProxyUrl(resolvedUrl, proxyBase, 'fetch');
+          }
+        }
+        return parts.join(' ');
+      }).join(', ');
+      $elem.attr('srcset', rewrittenSrcset);
+    }
+  });
+  
+  // Rewrite inline styles with url()
+  $('[style]').each((_, elem) => {
+    const $elem = $(elem);
+    const style = $elem.attr('style');
+    if (style) {
+      $elem.attr('style', rewriteCssUrls(style, baseUrl, proxyBase));
+    }
+  });
+  
+  // Rewrite <style> tags
+  $('style').each((_, elem) => {
+    const $elem = $(elem);
+    const css = $elem.html();
+    if (css) {
+      $elem.html(rewriteCssUrls(css, baseUrl, proxyBase));
+    }
+  });
+  
+  // Add base tag for any missed relative URLs (fallback)
+  // Remove existing base tags first
+  $('base').remove();
+  
+  return $.html();
+}
+
+/**
+ * Rewrite URLs in CSS content
+ */
+function rewriteCssUrls(css, baseUrl, proxyBase) {
+  // Rewrite url() declarations
+  css = css.replace(/url\(\s*['"]?([^'"\)]+)['"]?\s*\)/gi, (match, url) => {
+    const resolvedUrl = resolveUrl(baseUrl, url.trim());
+    if (resolvedUrl) {
+      return `url('${createProxyUrl(resolvedUrl, proxyBase, 'fetch')}')`;
+    }
+    return match;
+  });
+  
+  // Rewrite @import declarations
+  css = css.replace(/@import\s+['"]([^'"]+)['"]|@import\s+url\(['"]?([^'"\)]+)['"]?\)/gi, (match, url1, url2) => {
+    const url = url1 || url2;
+    const resolvedUrl = resolveUrl(baseUrl, url?.trim());
+    if (resolvedUrl) {
+      return `@import url('${createProxyUrl(resolvedUrl, proxyBase, 'fetch')}')`;
+    }
+    return match;
+  });
+  
+  return css;
+}
+
+/**
+ * Determine content type from headers or URL
+ */
+function getContentCategory(contentType, url) {
+  if (!contentType) {
+    // Guess from URL extension
+    const ext = url.split('?')[0].split('.').pop()?.toLowerCase();
+    if (['css'].includes(ext)) return 'css';
+    if (['html', 'htm'].includes(ext)) return 'html';
+    return 'other';
+  }
+  
+  if (contentType.includes('text/html') || contentType.includes('application/xhtml')) {
+    return 'html';
+  }
+  if (contentType.includes('text/css')) {
+    return 'css';
+  }
+  return 'other';
+}
+
 // Health check
 app.get('/', (req, res) => {
   res.json({
     status: 'ok',
     service: 'cz-web-proxy',
+    version: '1.1.0',
     endpoints: {
-      fetch: '/fetch?url=<encoded_url>',
-      stream: '/stream?url=<encoded_url>',
+      browse: '/browse?url=<encoded_url> - Full page rendering with URL rewriting',
+      fetch: '/fetch?url=<encoded_url> - Raw content fetch',
+      stream: '/stream?url=<encoded_url> - Streaming (for video/audio)',
       health: '/health'
     }
   });
@@ -26,7 +189,49 @@ app.get('/health', (req, res) => {
   res.json({ status: 'healthy', timestamp: new Date().toISOString() });
 });
 
-// Proxy fetch endpoint
+// Browse endpoint - full page rendering with URL rewriting
+app.get('/browse', async (req, res) => {
+  const targetUrl = req.query.url;
+  if (!targetUrl) {
+    return res.status(400).json({ error: 'Missing url parameter' });
+  }
+
+  try {
+    const backendUrl = `${PROXY_BACKEND}/?url=${encodeURIComponent(targetUrl)}`;
+    const response = await fetch(backendUrl);
+    const text = await response.text();
+    
+    let data;
+    try {
+      data = JSON.parse(text);
+    } catch (e) {
+      return res.status(500).json({ error: 'Invalid JSON from backend', details: text.substring(0, 200) });
+    }
+    
+    if (data.success && data.body) {
+      const contentType = data.contentType || 'text/html';
+      const proxyBase = `${req.protocol}://${req.get('host')}`;
+      const contentCategory = getContentCategory(contentType, targetUrl);
+      
+      let body = data.body;
+      
+      if (contentCategory === 'html') {
+        body = rewriteHtml(body, targetUrl, proxyBase);
+      } else if (contentCategory === 'css') {
+        body = rewriteCssUrls(body, targetUrl, proxyBase);
+      }
+      
+      res.setHeader('Content-Type', contentType);
+      res.send(body);
+    } else {
+      res.status(500).json({ error: data.error || 'Proxy error' });
+    }
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+});
+
+// Proxy fetch endpoint - with optional URL rewriting for CSS
 app.get('/fetch', async (req, res) => {
   const targetUrl = req.query.url;
   if (!targetUrl) {
@@ -34,9 +239,7 @@ app.get('/fetch', async (req, res) => {
   }
 
   try {
-    // PHP backend uses ?url= directly
     const backendUrl = `${PROXY_BACKEND}/?url=${encodeURIComponent(targetUrl)}`;
-    
     const response = await fetch(backendUrl);
     const text = await response.text();
     
@@ -47,11 +250,20 @@ app.get('/fetch', async (req, res) => {
       return res.status(500).json({ error: 'Invalid JSON from backend' });
     }
     
-    // Return the body from the proxy response
     if (data.success && data.body) {
       const contentType = data.contentType || 'text/plain';
+      const proxyBase = `${req.protocol}://${req.get('host')}`;
+      const contentCategory = getContentCategory(contentType, targetUrl);
+      
+      let body = data.body;
+      
+      // Rewrite CSS URLs so fonts and images load correctly
+      if (contentCategory === 'css') {
+        body = rewriteCssUrls(body, targetUrl, proxyBase);
+      }
+      
       res.setHeader('Content-Type', contentType);
-      res.send(data.body);
+      res.send(body);
     } else {
       res.status(500).json({ error: data.error || 'Proxy error' });
     }
@@ -60,7 +272,7 @@ app.get('/fetch', async (req, res) => {
   }
 });
 
-// Proxy stream endpoint
+// Proxy stream endpoint (unchanged - for binary streaming)
 app.get('/stream', (req, res) => {
   const targetUrl = req.query.url;
   if (!targetUrl) {
@@ -68,12 +280,10 @@ app.get('/stream', (req, res) => {
   }
 
   try {
-    // PHP backend uses ?action=stream&url=
     const backendUrl = new URL(PROXY_BACKEND);
     backendUrl.searchParams.set('action', 'stream');
     backendUrl.searchParams.set('url', targetUrl);
     
-    // Forward range header if present
     const rangeHeader = req.headers.range;
     
     const options = {
@@ -89,7 +299,6 @@ app.get('/stream', (req, res) => {
     }
 
     const proxyReq = http.request(options, (proxyRes) => {
-      // Forward status and headers
       res.status(proxyRes.statusCode);
       
       const headersToForward = [
@@ -105,7 +314,6 @@ app.get('/stream', (req, res) => {
         }
       });
 
-      // Pipe the response
       proxyRes.pipe(res);
     });
 
@@ -120,5 +328,5 @@ app.get('/stream', (req, res) => {
 });
 
 app.listen(PORT, () => {
-  console.log(`CZ Web Proxy running on port ${PORT}`);
+  console.log(`CZ Web Proxy v1.1.0 running on port ${PORT}`);
 });


### PR DESCRIPTION
## Summary

Closes #2

This PR implements a full URL rewriting proxy that enables complete page rendering with all assets (CSS, JS, images) loading through the Czech IP proxy.

### Changes

- **New `/browse` endpoint**: Full page rendering with automatic URL rewriting
- **HTML URL rewriting**: Rewrites `href`, `src`, `srcset`, `action`, `data-*` attributes
- **CSS URL rewriting**: Rewrites `url()` and `@import` declarations in both external CSS and inline styles
- **Smart link handling**: Internal links use `/browse` to maintain browsing context, assets use `/fetch`
- **Support for all URL formats**:
  - Absolute URLs (`https://...`)
  - Protocol-relative URLs (`//...`)
  - Root-relative URLs (`/path/...`)
  - Relative URLs (`../path/...`)

### Technical Details

- Added `cheerio` dependency for HTML parsing
- Version bumped to 1.1.0
- Existing `/fetch` endpoint now also rewrites CSS URLs for proper font/image loading
- `/stream` endpoint unchanged (for binary video/audio streaming)

### Usage

```
https://cz-web-proxy.azurewebsites.net/browse?url=https://prehrajto.cz/
https://cz-web-proxy.azurewebsites.net/browse?url=https://www.bombuj.si/
```

### Test Plan

- [ ] Verify `/browse` endpoint loads prehrajto.cz with CSS styling
- [ ] Verify images display correctly
- [ ] Verify internal links stay within proxy
- [ ] Verify CSS fonts and background images load
- [ ] Test with bombuj.si as secondary test case